### PR TITLE
Ao3 6388 add confirmation page and email when a user changes their email

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -74,7 +74,10 @@ class Admin::AdminUsersController < Admin::BaseController
     authorize @user
 
     attributes = permitted_attributes(@user)
-    @user.email = attributes[:email] if attributes[:email].present?
+    if attributes[:email].present?
+      @user.skip_reconfirmation!
+      @user.email = attributes[:email]
+    end
     @user.roles = Role.where(id: attributes[:roles]) if attributes[:roles].present?
 
     if @user.save

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -281,7 +281,8 @@ public
     store_location
     if logged_in?
       destination = options[:redirect].blank? ? user_path(current_user) : options[:redirect]
-      flash[:error] = ts "Sorry, you don't have permission to access the page you were trying to reach."
+      # i18n-tasks-use t('users.reconfirm_email.access_denied.logged_in')
+      flash[:error] = t(".access_denied.logged_in", default: t("application.access_denied.access_denied.logged_in")) # rubocop:disable I18n/DefaultTranslation
       redirect_to destination
     else
       destination = options[:redirect].blank? ? new_user_session_path : options[:redirect]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -163,12 +163,12 @@ class UsersController < ApplicationController
   def confirm_change_email
     @page_subtitle = t(".browser_title")
 
+    render :change_email and return unless reauthenticate
+
     if params[:new_email].blank?
       flash[:error] = t("users.confirm_change_email.blank_email")
       render :change_email and return
     end
-
-    render :change_email and return unless reauthenticate
 
     @new_email = params[:new_email]
 
@@ -180,10 +180,18 @@ class UsersController < ApplicationController
     #
     # Also, email addresses are validated on the client, and will only contain
     # a limited subset of ASCII, so we don't need to do a unicode casefolding pass.
-    return if @new_email.downcase == params[:email_confirmation].downcase
+    if @new_email.downcase != params[:email_confirmation].downcase
+      flash[:error] = t("users.confirm_change_email.nonmatching_email")
+      render :change_email and return
+    end
 
-    flash[:error] = t("users.confirm_change_email.nonmatching_email")
-    render :change_email and return
+    old_email = @user.email
+    @user.email = @new_email
+    if @user.invalid?(:update)
+      # Make sure that on failure, the form doesn't show the new invalid email as the current one
+      @user.email = old_email
+      render :change_email and return
+    end
   end
 
   def changed_email

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -194,7 +194,7 @@ class UsersController < ApplicationController
 
     if @user.save
       I18n.with_locale(@user.preference.locale.iso) do
-        UserMailer.change_email(@user.id, old_email, new_email).deliver_later # TODO Bilka fix all of this
+        UserMailer.change_email(@user.id, old_email, new_email).deliver_later
       end
     else
       # Make sure that on failure, the form still shows the old email as the "current" one.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -160,6 +160,21 @@ class UsersController < ApplicationController
     end
   end
 
+  # TODO Bilka If they are logged in to a different account, they should be redirected to the homepage with a custom error message (not the usual "Sorry, you don't have permission to access the page you were trying to reach.")
+  #   But also the redirect for logged out should use the standard error
+  # GET /users/1/reconfirm_email?confirmation_token=abcdef
+  def reconfirm_email
+    confirmed_user = User.confirm_by_token(params[:confirmation_token])
+
+    if confirmed_user.errors.empty?
+      flash[:notice] = t(".success")
+    else
+      flash[:error] = t(".invalid_token")
+    end
+
+    redirect_to change_email_user_path(@user)
+  end
+
   def changed_email
     if !params[:new_email].blank? && reauthenticate
       new_email = params[:new_email]
@@ -181,9 +196,9 @@ class UsersController < ApplicationController
       @user.email = new_email
 
       if @user.save
-        flash.now[:notice] = ts("Your email has been successfully updated")
+        flash.now[:notice] = ts("Your email has been successfully updated") # TODO Bilka fix all of this
         I18n.with_locale(@user.preference.locale.iso) do
-          UserMailer.change_email(@user.id, old_email, new_email).deliver_later
+          UserMailer.change_email(@user.id, old_email, new_email).deliver_later # TODO Bilka fix all of this
         end
       else
         # Make sure that on failure, the form still shows the old email as the "current" one.

--- a/app/mailers/archive_devise_mailer.rb
+++ b/app/mailers/archive_devise_mailer.rb
@@ -24,8 +24,7 @@ class ArchiveDeviseMailer < Devise::Mailer
 
   def confirmation_instructions(record, token, opts = {})
     @token = token
-    subject =  t("users.mailer.confirmation_instructions.subject",
-                 app_name: ArchiveConfig.APP_SHORT_NAME)
+    subject = t("users.mailer.confirmation_instructions.subject", app_name: ArchiveConfig.APP_SHORT_NAME)
     devise_mail(record, :confirmation_instructions, opts.merge(subject: subject))
   end
 end

--- a/app/mailers/archive_devise_mailer.rb
+++ b/app/mailers/archive_devise_mailer.rb
@@ -21,4 +21,11 @@ class ArchiveDeviseMailer < Devise::Mailer
     devise_mail(record, :reset_password_instructions,
                 options.merge(subject: subject))
   end
+
+  def confirmation_instructions(record, token, opts = {})
+    @token = token
+    subject =  t("users.mailer.confirmation_instructions.subject",
+                 app_name: ArchiveConfig.APP_SHORT_NAME)
+    devise_mail(record, :confirmation_instructions, opts.merge(subject: subject))
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -217,6 +217,7 @@ class UserMailer < ApplicationMailer
     @user = User.find(user_id)
     @old_email = old_email
     @new_email = new_email
+    @pac_footer = true
     mail(
       to: @old_email,
       subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME)

--- a/app/views/admin/mailer/reset_password_instructions.html.erb
+++ b/app/views/admin/mailer/reset_password_instructions.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@resource.login)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@resource.login)) %></p>
   <p><%= t(".intro") %></p>
   <p><%= style_link t(".link_title_html"), edit_admin_password_url(reset_password_token: @token) %></p>
   <p><%= t(".expiration", count: ArchiveConfig.DAYS_UNTIL_ADMIN_RESET_PASSWORD_LINK_EXPIRES) %></p>

--- a/app/views/admin/mailer/reset_password_instructions.text.erb
+++ b/app/views/admin/mailer/reset_password_instructions.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @resource.login) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @resource.login) %>
 
 <%= t(".intro") %>
 

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -95,12 +95,16 @@
                             <p><%= yield(:footer_note) %></p>
                           <% end %>
 
-                          <p><%= t("mailer.general.footer.general.unwanted_email.html", support_link: style_footer_link(t("mailer.general.footer.general.html.support_link_text"), new_feedback_report_url)) %></p>
+                          <% if @pac_footer %>
+                            <p><%= t("mailer.general.footer.why_policy_abuse.html", contact_policy_abuse_link: style_footer_link(t("mailer.general.footer.why_policy_abuse.contact_policy_abuse"), new_abuse_report_url)) %></p>
+                          <% else %>
+                            <p><%= t("mailer.general.footer.why_support.html", contact_support_link: style_footer_link(t("mailer.general.footer.why_support.contact_support"), new_feedback_report_url)) %></p>
+                          <% end %>
 
-                          <p><%= t("mailer.general.footer.general.about.html", donate_link: style_footer_link(t("mailer.general.footer.general.html.donate_link_text"), donate_url)) %></p>
+                          <p><%= t("mailer.general.footer.about.html", your_donations_link: style_footer_link(t("mailer.general.footer.about.your_donations"), donate_url)) %></p>
 
                           <% if content_for?(:sent_at) %>
-                            <p><%= t 'mailer.general.footer.sent_at', sent_at: yield(:sent_at).strip %></p>
+                            <p><%= t("mailer.general.footer.sent_at", sent_at: yield(:sent_at).strip) %></p>
                           <% end %>
 <!-- /footer -->
 

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -11,11 +11,15 @@ Archive of Our Own
 <%= yield(:footer_note) %>
 
 <% end %>
-<%= t 'mailer.general.footer.general.unwanted_email.text', support_url: new_feedback_report_url %>
+<% if @pac_footer %>
+<%= t("mailer.general.footer.why_policy_abuse.text", contact_policy_abuse_url: new_abuse_report_url) %>
+<% else %>
+<%= t("mailer.general.footer.why_support.text", contact_support_url: new_feedback_report_url) %>
+<% end %>
 
-<%= t 'mailer.general.footer.general.about.text', donate_url: donate_url %>
+<%= t("mailer.general.footer.about.text", your_donations_url: donate_url) %>
 <% if content_for?(:sent_at) %>
 
-<%= t 'mailer.general.footer.sent_at', sent_at: yield(:sent_at).strip %>
+<%= t("mailer.general.footer.sent_at", sent_at: yield(:sent_at).strip) %>
 
 <% end %>

--- a/app/views/preferences/index.html.erb
+++ b/app/views/preferences/index.html.erb
@@ -11,8 +11,9 @@
   <li><%= link_to t(".navigation.manage_my_pseuds"), user_pseuds_path(@user) %></li>
   <li><%= link_to t(".navigation.blocked_users"), user_blocked_users_path %></li>
   <li><%= link_to t(".navigation.muted_users"), user_muted_users_path %></li>
-  <li><%= link_to t(".navigation.change_my_username"), change_username_user_path(@user) %></li>
-  <li><%= link_to t(".navigation.orphan_my_works"), new_orphan_path %></li>
+  <li><%= link_to t(".navigation.change_username"), change_username_user_path(@user) %></li>
+  <li><%= link_to t(".navigation.change_password"), change_password_user_path(@user) %></li>
+  <li><%= link_to t(".navigation.change_email"), change_email_user_path(@user) %></li>
 </ul>
 <!--/subnav-->
 

--- a/app/views/tos_update_mailer/tos_update_notification.html.erb
+++ b/app/views/tos_update_mailer/tos_update_notification.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@username)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@username)) %></p>
 
   <p>In order to make AO3's rules clearer to our users, we intend to update the AO3 Terms of Service (TOS) later this year. Once this occurs, you will need to agree to the updated TOS in order to continue using AO3.</p>
 

--- a/app/views/tos_update_mailer/tos_update_notification.text.erb
+++ b/app/views/tos_update_mailer/tos_update_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @username) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @username) %>
 
 In order to make AO3's rules clearer to our users, we intend to update the AO3 Terms of Service (TOS) later this year. Once this occurs, you will need to agree to the updated TOS in order to continue using AO3.
 

--- a/app/views/user_mailer/admin_deleted_work_notification.html.erb
+++ b/app/views/user_mailer/admin_deleted_work_notification.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@user.login)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@user.login)) %></p>
 
   <p><%= t(".deleted.html", title: style_creation_title(@work.title)) %></p>
 

--- a/app/views/user_mailer/admin_deleted_work_notification.text.erb
+++ b/app/views/user_mailer/admin_deleted_work_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @user.login) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @user.login) %>
 
 <%= t(".deleted.text", title: @work.title) %>
 

--- a/app/views/user_mailer/admin_hidden_work_notification.html.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@user.login)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@user.login)) %></p>
 
   <p><%= t(".hidden.html", title: style_creation_link(@work.title, @work)) %></p>
 

--- a/app/views/user_mailer/admin_hidden_work_notification.text.erb
+++ b/app/views/user_mailer/admin_hidden_work_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @user.login) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @user.login) %>
 
 <%= t(".hidden.text", title: @work.title, work_url: work_url(@work)) %>
 

--- a/app/views/user_mailer/admin_spam_work_notification.html.erb
+++ b/app/views/user_mailer/admin_spam_work_notification.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@user.login)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@user.login)) %></p>
 
   <p>Your work <%= style_creation_link(@work.title, @work) %> has been flagged by our automated system as spam and hidden until it can be reviewed by our Policy & Abuse team. While the work is hidden it can only be accessed by you and AO3 site admins.</p>
 

--- a/app/views/user_mailer/admin_spam_work_notification.text.erb
+++ b/app/views/user_mailer/admin_spam_work_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @user.login) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @user.login) %>
 
 Your work "<%= @work.title.html_safe %>" (<%= work_url(@work) %>) has been flagged by our automated system as spam and hidden until it can be reviewed by our Abuse team. While the work is hidden it can only be accessed by you and AO3 site admins.
 

--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.html.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@user.login)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@user.login)) %></p>
 
   <p><%= t(".changed_status.#{@status}.html",
            collection_link: style_link(@collection.title, collection_url(@collection)),

--- a/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
+++ b/app/views/user_mailer/anonymous_or_unrevealed_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @user.login) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @user.login) %>
 
 <%= t(".changed_status.#{@status}.text",
       collection_title: @collection.title,

--- a/app/views/user_mailer/archivist_added_to_collection_notification.html.erb
+++ b/app/views/user_mailer/archivist_added_to_collection_notification.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@user.login)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@user.login)) %></p>
 
   <p>
     <%= t(".work_added.html", 

--- a/app/views/user_mailer/archivist_added_to_collection_notification.text.erb
+++ b/app/views/user_mailer/archivist_added_to_collection_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @user.login) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @user.login) %>
 
 <%= t(".work_added.text",
       collection_title: @collection.title,

--- a/app/views/user_mailer/change_email.html.erb
+++ b/app/views/user_mailer/change_email.html.erb
@@ -1,3 +1,11 @@
 <% content_for :message do %>
-  <%= t('.changed.html', login: style_bold(@user.login), email: style_email(@user.email)) %>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@user.login)) %></p>
+
+  <p><%= t(".made_request", app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
+
+  <p><%= t(".confirm_change.html", unconfirmed_email: style_email(@new_email), count: User.confirm_within.in_days.to_i, contact_support_link: link_to(t(".contact_support"), new_feedback_report_url)) %></p>
+
+  <p><%= t(".wrong_email.html", email_change_form_link: link_to(t(".email_change_form"), change_email_user_url(@user))) %></p>
+
+  <p><%= t(".not_made_request.html", reset_password_link: link_to(t(".reset_password"), new_user_password_url), contact_policy_abuse_link: link_to(t(".contact_policy_abuse"), new_abuse_report_url)) %></p>
 <% end %>

--- a/app/views/user_mailer/change_email.text.erb
+++ b/app/views/user_mailer/change_email.text.erb
@@ -1,3 +1,11 @@
 <% content_for :message do %>
-<%= t('.changed.text', login: @user.login, email: @user.email) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @user.login) %>
+
+<%= t(".made_request", app_name: ArchiveConfig.APP_SHORT_NAME) %>
+
+<%= t(".confirm_change.text", unconfirmed_email: @new_email, count: User.confirm_within.in_days.to_i, contact_support_url: new_feedback_report_url) %>
+
+<%= t(".wrong_email.text", email_change_form_url: change_email_user_url(@user)) %>
+
+<%= t(".not_made_request.text", reset_password_url: new_user_password_url, contact_policy_abuse_url: new_abuse_report_url) %>
 <% end %>

--- a/app/views/user_mailer/delete_work_notification.html.erb
+++ b/app/views/user_mailer/delete_work_notification.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@user.login)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@user.login)) %></p>
     <% if @user == @deleter || !@deleter %>
       <p><%= t(".deleted_yourself.html", title: style_creation_title(@work.title)) %></p>
     <% else %>

--- a/app/views/user_mailer/delete_work_notification.text.erb
+++ b/app/views/user_mailer/delete_work_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @user.login) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @user.login) %>
 
 <% if @user == @deleter || !@deleter %>
 <%= t(".deleted_yourself.text", title: @work.title) %>

--- a/app/views/user_mailer/invite_request_declined.html.erb
+++ b/app/views/user_mailer/invite_request_declined.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@user.login)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@user.login)) %></p>
 
   <p><%= t(".main", count: @total) %></p>
   <p><%= t(".reason") %></p>

--- a/app/views/user_mailer/invite_request_declined.text.erb
+++ b/app/views/user_mailer/invite_request_declined.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @user.login) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @user.login) %>
 
 <%= t(".main", count: @total) %>
 

--- a/app/views/user_mailer/invited_to_collection_notification.html.erb
+++ b/app/views/user_mailer/invited_to_collection_notification.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@user.login)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@user.login)) %></p>
 
   <p>The collection maintainers of <%= style_link(@collection.title, collection_url(@collection)) %> would
     like to include your work <%= style_creation_link(@work.title, work_url(@work)) %> in their collection!</p>

--- a/app/views/user_mailer/invited_to_collection_notification.text.erb
+++ b/app/views/user_mailer/invited_to_collection_notification.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @user.login) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @user.login) %>
 
 The collection maintainers of "<%= @collection.title %>" (<%= collection_url(@collection) %>) would like to include your work "<%= @work.title.html_safe %>" (<%= work_url(@work) %>) in their collection!
 

--- a/app/views/users/change_email.html.erb
+++ b/app/views/users/change_email.html.erb
@@ -1,30 +1,45 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("Change My Email") %></h2>
+<h2 class="heading"><%= t(".heading") %></h2>
 <%= error_messages_for :user %>
 <!--/descriptions-->
 
 <!--subnav-->
-<%= render 'edit_header_navigation' %>
+<%= render "edit_header_navigation" %>
 <!--/subnav-->
 
+<% reconfirmation_date = @user.confirmation_sent_at + User.confirm_within if @user.pending_reconfirmation? %>
+<% if reconfirmation_date && (Time.current < reconfirmation_date) %>
+  <div class="caution notice">
+    <p><%= t(".caution.requested_change_html", unconfirmed_email: tag.strong(@user.unconfirmed_email)) %></p>
+    <p><%= t(".caution.check_spam_html", must_confirm_bold: tag.strong(t(".caution.must_confirm")), contact_support_link: link_to(t(".caution.contact_support"), new_feedback_report_path)) %></p>
+    <p><strong><%= t(".caution.confirm_by", date: l(reconfirmation_date.to_date, format: :long)) %></strong></p>
+  </div>
+<% end %>
+
+<div class="notice">
+  <p><%= t(".request_for_confirmation") %></p>
+  <p><%= t(".must_confirm", count: User.confirm_within.in_days.to_i) %></p>
+  <p><%= t(".resubmission_html", invalidate_bold: tag.strong(t(".invalidate"))) %> </p>
+</div>
+
 <!--main content-->
-<%= form_tag changed_email_user_path(@user) do %>
+<%= form_with model: @user, url: confirm_change_email_user_path(@user), method: :put do %>
   <dl>
-    <dt><%= ts("Current Email") %></dt>
+    <dt><%= t(".form.current_email") %></dt>
     <dd><%= @user.email %></dd>
 
-    <dt><%= label_tag :new_email, ts("New Email") %></dt>
+    <dt><%= label_tag :new_email, t(".form.new_email") %></dt>
     <dd><%= email_field_tag :new_email %></dd>
 
-    <dt><%= label_tag :email_confirmation, ts("Confirm New Email") %></dt>
+    <dt><%= label_tag :email_confirmation, t(".form.email_again") %></dt>
     <dd><%= email_field_tag :email_confirmation %></dd>
 
-    <dt><%= label_tag :password_check, ts("Password") %></dt>
+    <dt><%= label_tag :password_check, t(".form.password") %></dt>
     <dd><%= password_field_tag :password_check %></dd>
 
-    <dt class="landmark"><%= label_tag :submit, ts("Submit") %></dt>
+    <dt class="landmark"><%= label_tag :submit, t(".form.submit_landmark") %></dt>
     <dd class="submit actions">
-      <%= submit_tag ts("Change Email") %>
+      <%= submit_tag t(".form.confirm") %>
     </dd>
   </dl>
 <% end %>

--- a/app/views/users/confirm_change_email.html.erb
+++ b/app/views/users/confirm_change_email.html.erb
@@ -1,0 +1,24 @@
+<!--Descriptive page name, messages and instructions-->
+<h2 class="heading"><%= t(".heading") %></h2>
+<!--/descriptions-->
+
+<!--subnav-->
+<%= render "edit_header_navigation" %>
+<!--/subnav-->
+
+<!--main content-->
+<%= form_with model: @user, url: changed_email_user_path(@user), method: :post do %>
+  <%= hidden_field_tag :new_email, @new_email %>
+
+  <div class="caution notice">
+    <p><%= t(".are_you_sure_html", unconfirmed_email: tag.strong(@new_email)) %></p>
+    <p><%= t(".confirm_via_link_html", if_not_confirm_bold: tag.strong(t(".if_not_confirm", count: User.confirm_within.in_days.to_i))) %></p>
+  </div>
+
+  <p class="actions">
+    <%= link_to t(".cancel"), change_email_user_path(@user) %>
+    <%= submit_tag t(".confirm") %>
+  </p>
+<% end %>
+
+<!--/content-->

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,11 @@
+<% content_for :message do %>
+  <p><%= t("mailer.general.greeting.formal.unaddressed") %></p>
+
+  <p><%= t(".request_to_change_email_html", username: style_bold(@resource.login)) %></p>
+
+  <p><%= t(".made_request.html", count: @resource.class.confirm_within.in_days.to_i, confirm_email_change_link: link_to(t(".confirm_email_change"), reconfirm_email_user_url(@resource, confirmation_token: @token))) %></p>
+
+  <p><%= t(".confirm_by.html", date: l((@resource.confirmation_sent_at + @resource.class.confirm_within).to_date, format: :long), email_change_form_link: link_to(t(".email_change_form"), change_email_user_url(@user))) %></p>
+
+  <p><%= t(".did_not_make_request") %></p>
+<% end %>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
   <p><%= t("mailer.general.greeting.formal.unaddressed") %></p>
 
-  <p><%= t(".request_to_change_email_html", username: style_bold(@resource.login)) %></p>
+  <p><%= t(".request_to_change_email_html", username: style_bold(@resource.login), app_name: ArchiveConfig.APP_SHORT_NAME) %></p>
 
   <p><%= t(".made_request.html", count: @resource.class.confirm_within.in_days.to_i, confirm_email_change_link: link_to(t(".confirm_email_change"), reconfirm_email_user_url(@resource, confirmation_token: @token))) %></p>
 

--- a/app/views/users/mailer/confirmation_instructions.text.erb
+++ b/app/views/users/mailer/confirmation_instructions.text.erb
@@ -1,0 +1,11 @@
+<% content_for :message do %>
+<%= t("mailer.general.greeting.formal.unaddressed") %>
+
+<%= t(".request_to_change_email_html", username: @resource.login) %>
+
+<%= t(".made_request.text", count: @resource.class.confirm_within.in_days.to_i, confirm_email_change_url: reconfirm_email_user_url(@resource, confirmation_token: @token)) %>
+
+<%= t(".confirm_by.text", date: l((@resource.confirmation_sent_at + @resource.class.confirm_within).to_date, format: :long), email_change_form_url: change_email_user_url(@user)) %>
+
+<%= t(".did_not_make_request") %>
+<% end %>

--- a/app/views/users/mailer/confirmation_instructions.text.erb
+++ b/app/views/users/mailer/confirmation_instructions.text.erb
@@ -1,7 +1,7 @@
 <% content_for :message do %>
 <%= t("mailer.general.greeting.formal.unaddressed") %>
 
-<%= t(".request_to_change_email_html", username: @resource.login) %>
+<%= t(".request_to_change_email_html", username: @resource.login, app_name: ArchiveConfig.APP_SHORT_NAME) %>
 
 <%= t(".made_request.text", count: @resource.class.confirm_within.in_days.to_i, confirm_email_change_url: reconfirm_email_user_url(@resource, confirmation_token: @token)) %>
 

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-  <p><%= t("mailer.general.greeting.formal_html", name: style_bold(@resource.login)) %></p>
+  <p><%= t("mailer.general.greeting.formal.addressed_html", name: style_bold(@resource.login)) %></p>
   <p><%= t(".intro") %></p>
   <p><%= style_link t(".link_title"), edit_user_password_url(reset_password_token: @token) %></p>
   <p><%= t(".expiration") %></p>

--- a/app/views/users/mailer/reset_password_instructions.text.erb
+++ b/app/views/users/mailer/reset_password_instructions.text.erb
@@ -1,5 +1,5 @@
 <% content_for :message do %>
-<%= t("mailer.general.greeting.formal_html", name: @resource.login) %>
+<%= t("mailer.general.greeting.formal.addressed_html", name: @resource.login) %>
 
 <%= t(".intro") %>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -124,8 +124,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  # config.reconfirmable = true
-  config.reconfirmable = false
+  config.reconfirmable = true
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -25,6 +25,10 @@ en:
         success:
           one: Successfully removed pseud %{pseuds} from this work.
           other: Successfully removed pseuds %{pseuds} from this work.
+  application:
+    access_denied:
+      access_denied:
+        logged_in: Sorry, you don't have permission to access the page you were trying to reach.
   archive_faqs:
     create:
       success: Archive FAQ was successfully created.
@@ -213,6 +217,8 @@ en:
           other: You may reset your password %{count} more times.
         user_not_found: We couldn't find an account with that email address or username. Please try again.
     reconfirm_email:
+      access_denied:
+        logged_in: You are not logged in to the account whose email you are trying to change. Please log out and try again.
       invalid_token: This email confirmation link is invalid or expired. Please check your email for the correct link or submit the email change form again.
       success: Your email has been successfully updated.
     status:

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -202,6 +202,9 @@ en:
           one: You may reset your password %{count} more time.
           other: You may reset your password %{count} more times.
         user_not_found: We couldn't find an account with that email address or username. Please try again.
+    reconfirm_email:
+      invalid_token: This email confirmation link is invalid or expired. Please check your email for the correct link or submit the email change form again.
+      success: Your email has been successfully updated.
     status:
       ban_notice_html: Your account has been banned. You are not permitted to post or edit content on AO3. Please check your email or %{contact_abuse_link} for more information.
       suspension_notice_html: Your account has been suspended until %{suspended_until}. You cannot post, edit, or delete content until your suspension has ended. Please check your email or %{contact_abuse_link} for more information.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -182,12 +182,22 @@ en:
     index:
       collection_page_title: "%{collection_title} - Tags"
   users:
+    changed_password:
+      blank_password: You must enter your old password.
+      wrong_password: Your old password was incorrect.
     changed_username:
       admin:
         successfully_updated: Username has been successfully updated.
       user:
         incorrect_password: Your password was incorrect
         successfully_updated: Your username has been successfully updated.
+    confirm_change_email:
+      blank_email: You must enter a new email address.
+      blank_password: You must enter your password.
+      browser_title: Confirm New Email
+      contact_support: contact Support
+      nonmatching_email: Email addresses don't match! Please retype and try again.
+      wrong_password_html: Your password was incorrect. Please try again or log out and reset your password via the link on the login form. If you are still having trouble, %{contact_support_link} for help.
     contact_abuse: contact our Policy & Abuse team
     passwords:
       create:

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -68,7 +68,9 @@ en:
             text: If you've received this message in error, please contact Support at %{support_url}.
         sent_at: Sent at %{sent_at}.
       greeting:
-        formal_html: Dear %{name},
+        formal:
+          addressed_html: Hi %{name},
+          unaddressed: Hi,
         informal:
           addressed_html: Hi, %{name}!
           unaddressed: Hi!
@@ -423,6 +425,22 @@ en:
       welcome: Welcome to the Archive of Our Own, %{login}!
   users:
     mailer:
+      confirmation_instructions:
+        confirm_by:
+          html: If you don't confirm your request by %{date}, the link in this email will expire and you will need to %{email_change_form_link} again.
+          text: 'If you don''t confirm your request by %{date}, the link in this email will expire and you will need to submit the email change form again: %{email_change_form_url}.'
+        confirm_email_change: confirm your email change
+        did_not_make_request: If you did not make this request, you can safely ignore and delete this email. Someone else may have entered your email address by mistake.
+        email_change_form: submit the email change form
+        made_request:
+          html:
+            one: If you made this request, please %{confirm_email_change_link} within %{count} day.
+            other: If you made this request, please %{confirm_email_change_link} within %{count} days.
+          text:
+            one: 'If you made this request, please confirm your email change within %{count} day: %{confirm_email_change_url}.'
+            other: 'If you made this request, please confirm your email change within %{count} days: %{confirm_email_change_url}.'
+        request_to_change_email_html: Someone has made a request to change the email address associated with the AO3 account %{username} to this email address.
+        subject: "[%{app_name}] Confirm your email change"
       reset_password_instructions:
         expiration: If you do not use this link to reset your password within a week, it will expire, and you will have to request a new one.
         intro: 'Someone has requested a password reset for your account. You can change your account password by following the link below and entering your new password:'

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -203,10 +203,25 @@ en:
       recipient_missing: 'None: contact a moderator for help!'
       subject: "[%{app_name}][%{collection_title}] Your assignment!"
     change_email:
-      changed:
-        html: "%{login}, the email associated with your account has been changed to %{email}"
-        text: "%{login}, the email associated with your account has been changed to %{email}"
-      subject: "[%{app_name}] Email changed"
+      confirm_change:
+        html:
+          one: If you made this request, check your email at %{unconfirmed_email} within %{count} day to confirm your email change. If you do not receive a confirmation email, or if you have other issues, please %{contact_support_link}.
+          other: If you made this request, check your email at %{unconfirmed_email} within %{count} days to confirm your email change. If you do not receive a confirmation email, or if you have other issues, please %{contact_support_link}.
+        text:
+          one: 'If you made this request, check your email at %{unconfirmed_email} within %{count} day to confirm your email change. If you do not receive a confirmation email, or if you have other issues, please contact Support: %{contact_support_url}.'
+          other: 'If you made this request, check your email at %{unconfirmed_email} within %{count} days to confirm your email change. If you do not receive a confirmation email, or if you have other issues, please contact Support: %{contact_support_url}.'
+      contact_policy_abuse: contact Policy & Abuse
+      contact_support: contact Support
+      email_change_form: submit the email change form
+      made_request: Someone has made a request to change the email address associated with your %{app_name} account.
+      not_made_request:
+        html: If you did not make this request, someone else may have access to your AO3 account. Please %{reset_password_link}. If you are unable to reset your password, %{contact_policy_abuse_link}.
+        text: 'If you did not make this request, someone else may have access to your AO3 account. Please reset your password now: %{reset_password_url}. If you are unable to reset your password, contact Policy & Abuse: %{contact_policy_abuse_url}.'
+      reset_password: reset your password now
+      subject: "[%{app_name}] Email change request"
+      wrong_email:
+        html: If you entered the wrong email address, you will need to %{email_change_form_link} again.
+        text: 'If you entered the wrong email address, you will need to submit the email change form again: %{email_change_form_url}.'
     claim_notification:
       access:
         contact_support: contact AO3 Support

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -56,17 +56,19 @@ en:
           one: "%{count} word"
           other: "%{count} words"
       footer:
-        general:
-          about:
-            html: The Archive of Our Own is a fan-run and fan-supported archive that relies on %{donate_link}.
-            text: 'The Archive of Our Own is a fan-run and fan-supported archive that relies on your donations: %{donate_url}.'
-          html:
-            donate_link_text: your donations
-            support_link_text: contact Support
-          unwanted_email:
-            html: If you've received this message in error, please %{support_link}.
-            text: If you've received this message in error, please contact Support at %{support_url}.
+        about:
+          html: The Archive of Our Own is a fan-run and fan-supported archive that relies on %{your_donations_link}.
+          text: 'The Archive of Our Own is a fan-run and fan-supported archive that relies on your donations: %{your_donations_url}.'
+          your_donations: your donations
         sent_at: Sent at %{sent_at}.
+        why_policy_abuse:
+          contact_policy_abuse: contact Policy & Abuse
+          html: If you don't understand why you received this email, please %{contact_policy_abuse_link}.
+          text: 'If you don''t understand why you received this email, please contact Policy & Abuse: %{contact_policy_abuse_url}.'
+        why_support:
+          contact_support: contact Support
+          html: If you don't understand why you received this email, please %{contact_support_link}.
+          text: 'If you don''t understand why you received this email, please contact Support: %{contact_support_url}.'
       greeting:
         formal:
           addressed_html: Hi %{name},

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -439,7 +439,7 @@ en:
           text:
             one: 'If you made this request, please confirm your email change within %{count} day: %{confirm_email_change_url}.'
             other: 'If you made this request, please confirm your email change within %{count} days: %{confirm_email_change_url}.'
-        request_to_change_email_html: Someone has made a request to change the email address associated with the AO3 account %{username} to this email address.
+        request_to_change_email_html: Someone has made a request to change the email address associated with the %{app_name} account %{username} to this email address.
         subject: "[%{app_name}] Confirm your email change"
       reset_password_instructions:
         expiration: If you do not use this link to reset your password within a week, it will expire, and you will have to request a new one.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1879,12 +1879,13 @@ en:
         turn_on_new_user_help: Turn the new user help banner back on.
       navigation:
         blocked_users: Blocked Users
-        change_my_username: Change My Username
+        change_email: Change Email
+        change_password: Change Password
+        change_username: Change Username
         edit_my_profile: Edit My Profile
         landmark: Navigation
         manage_my_pseuds: Manage My Pseuds
         muted_users: Muted Users
-        orphan_my_works: Orphan My Works
       page_heading: Set My Preferences
       privacy:
         allow_co_creator_invite: Allow others to invite me to be a co-creator.
@@ -2072,6 +2073,26 @@ en:
       ticket_id: Ticket ID
     change_email:
       browser_title: Change Email
+      caution:
+        check_spam_html: "%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email."
+        confirm_by: If you don't confirm your request by %{date}, your email address will not be changed.
+        contact_support: contact Support
+        must_confirm: You must use the link in the confirmation email in order to finish confirming your email change.
+        requested_change_html: You have requested to change your email address to %{unconfirmed_email}. A confirmation email has been sent to this address.
+      form:
+        confirm: Confirm New Email
+        current_email: Current email
+        email_again: Enter new email again
+        new_email: New email
+        password: Password
+        submit_landmark: Submit
+      heading: Change Email
+      invalidate: invalidate any pending email change requests
+      must_confirm:
+        one: You must use the link in the confirmation email in order to finish confirming your email change. If you don't confirm your request within %{count} day, the link will expire and your email address will not be changed.
+        other: You must use the link in the confirmation email in order to finish confirming your email change. If you don't confirm your request within %{count} days, the link will expire and your email address will not be changed.
+      request_for_confirmation: Changing your email will send a request for confirmation to your new email address and a notification to your current email address.
+      resubmission_html: Resubmitting this form with a new email address will %{invalidate_bold}.
     change_password:
       browser_title: Change Password
     change_username:
@@ -2096,6 +2117,15 @@ en:
       submit: Change Username
       submit_landmark: Submit
       username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
+    confirm_change_email:
+      are_you_sure_html: Are you sure you want to change your email address to %{unconfirmed_email}? A confirmation email will be sent to this address.
+      cancel: Cancel
+      confirm: Yes, Change Email
+      confirm_via_link_html: You must use the link in the confirmation email in order to finish confirming your email change. %{if_not_confirm_bold}
+      heading: Confirm New Email
+      if_not_confirm:
+        one: If you don't confirm your request within %{count} day, the link will expire and your email address will not be changed.
+        other: If you don't confirm your request within %{count} days, the link will expire and your email address will not be changed.
     confirmation:
       contact_support: contact Support
       go_back: Return to Archive front page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,6 +242,7 @@ Rails.application.routes.draw do
   resources :users, except: [:new, :create] do
     member do
       get :change_email
+      put :confirm_change_email
       post :changed_email
       get :change_password
       post :changed_password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,6 +250,7 @@ Rails.application.routes.draw do
       post :end_first_login
       post :end_banner
       post :end_tos_prompt
+      get :reconfirm_email
     end
     resources :assignments, controller: "challenge_assignments", only: [:index]
     resources :claims, controller: "challenge_claims", only: [:index]

--- a/db/migrate/20250407174814_add_unconfirmed_email_to_users.rb
+++ b/db/migrate/20250407174814_add_unconfirmed_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddUnconfirmedEmailToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :unconfirmed_email, :string
+  end
+end

--- a/db/migrate/20250407174814_add_unconfirmed_email_to_users.rb
+++ b/db/migrate/20250407174814_add_unconfirmed_email_to_users.rb
@@ -1,4 +1,6 @@
 class AddUnconfirmedEmailToUsers < ActiveRecord::Migration[7.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
   def change
     add_column :users, :unconfirmed_email, :string
   end

--- a/features/other_a/orphan_account.feature
+++ b/features/other_a/orphan_account.feature
@@ -19,7 +19,7 @@ Scenario: Orphan all works belonging to a user
     And I should see "Shenanigans 2"
     And I should see "Shenanigans - the early years"
   When I follow "Preferences"
-  When I follow "Orphan My Works"
+  When I go to the orphan all works page
   Then I should see "Orphan All Works"
     And I should see "Are you really sure you want to"
   When I choose "Take my pseud off as well"
@@ -52,7 +52,7 @@ Given I have an orphan account
     And I should see "Shenanigans 2"
     And I should see "Shenanigans - the early years"
   When I follow "Preferences"
-  When I follow "Orphan My Works"
+  When I go to the orphan all works page
   Then I should see "Orphan All Works"
     And I should see "Are you really sure you want to"
   When I choose "Leave a copy of my pseud on"

--- a/features/other_a/preferences_edit.feature
+++ b/features/other_a/preferences_edit.feature
@@ -62,7 +62,6 @@ Feature: Edit preferences
     And I should see "Profile" within "div#dashboard"
   When I follow "Preferences" within "div#dashboard"
   Then I should see "Set My Preferences"
-    And I should see "Orphan My Works"
   When I follow "Edit My Profile"
   Then I should see "Password"
   # TODO: figure out why pseud switcher doesn't show up in cukes

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -80,9 +80,8 @@ Scenario: Changing email address shows a confirmation page and sends a confirmat
     And I should see "If you don't confirm your request by April 14, 2020"
     And I should see "bar@ao3.org"
     And 1 email should be delivered to "bar@ao3.org"
-    # TODO Bilka
-    #And the email should contain "Someone has made a request to change the email address associated with your AO3 account."
-    #And the email should contain "valid2@archiveofourown.org"
+    And the email should contain "Someone has made a request to change the email address associated with your AO3 account."
+    And the email should contain "valid2@archiveofourown.org"
     And 1 email should be delivered to "valid2@archiveofourown.org"
     And the email should contain "request to change the email address associated with the AO3 account"
     And the email should contain "editname"
@@ -200,8 +199,7 @@ Scenario: Changing email address -- translated emails are sent when user enables
       And I follow "Change Email"
       And I request to change my email to "valid2@archiveofourown.org"
     Then the email address "bar@ao3.org" should be emailed
-      # TODO Bilka
-      #And the email should have "Email change request" in the subject
+      And the email should have "Email change request" in the subject
       And the email to email address "bar@ao3.org" should be translated
       And 1 email should be delivered to "valid2@archiveofourown.org"
       And the email should have "Confirm your email change" in the subject

--- a/features/other_a/profile_edit.feature
+++ b/features/other_a/profile_edit.feature
@@ -61,66 +61,117 @@ Scenario: Change details as an admin
   When I go to the admin-activities page
   Then I should see 1 admin activity log entry
 
-Scenario: Changing email address requires reauthenticating
+Scenario: Changing email address shows a confirmation page and sends a confirmation mail
 
-  When I follow "Change Email"
-    And I fill in "New Email" with "blah@a.com"
-    And I fill in "Confirm New Email" with "blah@a.com"
-    And I press "Change Email"
-  Then I should see "You must enter your password"
-    And 0 emails should be delivered
-
-Scenario: Changing email address - entering an invalid email address
-
-  When I enter an invalid email
-  Then I should see "Email should look like an email address"
-    And 0 emails should be delivered
-
-Scenario: Changing email address - case-insensitive confirmation
-
-  When I follow "Change Email"
-    And I fill in "New Email" with "foo@example.com"
-    And I fill in "Confirm New Email" with "FoO@example.com"
+  When it is currently 2020-04-10 13:37
+    And the email address change confirmation period is set to 4 days
+    And I change my preferences to display my email address
+    And I follow "Edit My Profile"
+    And I follow "Change Email"
+    And I fill in "New email" with "valid2@archiveofourown.org"
+    And I fill in "Enter new email again" with "valid2@archiveofourown.org"
     And I fill in "Password" with "password"
-    And I press "Change Email"
-  Then I should see "Your email has been successfully updated"
-    And 1 email should be delivered to "bar@ao3.org"
-    And all emails have been delivered
-    And the email should contain "the email associated with your account has been changed to"
-    And the email should contain "foo@example.com"
-    And the email should not contain "translation missing"
-  When I change my preferences to display my email address
-  Then I should see "My email address: foo@example.com"
-
-Scenario: Changing email address - entering an incorrect password
-
-  When I enter an incorrect password
-  Then I should see "Your password was incorrect"
+    And I press "Confirm New Email"
+  Then I should see "Are you sure you want to change your email address to valid2@archiveofourown.org?"
+    And I should see "If you don't confirm your request within 4 days"
     And 0 emails should be delivered
-
-Scenario: Changing email address - entering non-matching new email addresses
-
-  When I enter non-matching emails
-  Then I should see "Email addresses don't match!"
-    And 0 emails should be delivered
+  When I press "Yes, Change Email"
+  Then I should see "You have requested to change your email address to valid2@archiveofourown.org."
+    And I should see "If you don't confirm your request by April 14, 2020"
     And I should see "bar@ao3.org"
-
-Scenario: Changing email address and viewing
-
-  When I change my email
-  Then I should see "Your email has been successfully updated"
     And 1 email should be delivered to "bar@ao3.org"
-    And all emails have been delivered
-    And the email should contain "the email associated with your account has been changed to"
-    And the email should contain "valid2@archiveofourown.org"
-    And the email should not contain "translation missing"
-  When I change my preferences to display my email address
+    # TODO Bilka
+    #And the email should contain "Someone has made a request to change the email address associated with your AO3 account."
+    #And the email should contain "valid2@archiveofourown.org"
+    And 1 email should be delivered to "valid2@archiveofourown.org"
+    And the email should contain "request to change the email address associated with the AO3 account"
+    And the email should contain "editname"
+
+  When I am a visitor
+    And I follow "confirm your email change" in the email
+  Then I should see "Sorry, you don't have permission to access the page you were trying to reach. Please log in."
+  When I go to editname's profile page
+  Then I should see "My email address: bar@ao3.org"
+
+  When I am logged in as "editname"
+    And I follow "confirm your email change" in the email
+  Then I should see "Your email has been successfully updated."
+    And I should see "valid2@archiveofourown.org"
+    But I should not see "bar@ao3.org"
+    But I should not see "You have requested to change your email address"
+  When I go to editname's profile page
   Then I should see "My email address: valid2@archiveofourown.org"
   When I log out
     And I go to editname's profile page
   Then I should see "My email address: valid2@archiveofourown.org"
 
-Scenario: Changing email address after requesting password reset
+Scenario: Changing email address -- canceling in confirmation step
+
+  When I follow "Change Email"
+    And I start to change my email to "valid2@archiveofourown.org"
+  Then I should see "Are you sure you want to change your email address"
+    And 0 emails should be delivered
+  When I follow "Cancel"
+  Then I should see "Change Email" within "h2.heading"
+    And 0 emails should be delivered
+    And I should not see "You have requested to change your email address"
+
+Scenario: Changing email address -- request expires
+
+  When it is currently 2020-04-10 13:37
+    And the email address change confirmation period is set to 4 days
+    And I follow "Change Email"
+    And I request to change my email to "valid2@archiveofourown.org"
+  Then I should see "If you don't confirm your request by April 14, 2020"
+    And 1 email should be delivered to "valid2@archiveofourown.org"
+    And the email should contain "request to change the email address"
+    And I should see "You have requested to change your email address"
+
+  When it is currently 2020-04-15 14:00
+    And I follow "My Preferences"
+    And I follow "Change Email"
+  Then I should not see "You have requested to change your email address"
+    And I should see "bar@ao3.org"
+    But I should not see "valid2@archiveofourown.org"
+  When I follow "confirm your email change" in the email
+  Then I should see "This email confirmation link is invalid or expired. Please check your email for the correct link or submit the email change form again."
+    And I should see "bar@ao3.org"
+    But I should not see "valid2@archiveofourown.org"
+
+Scenario: Changing email address -- resubmitting form changes target email and expiration date
+
+  When it is currently 2020-04-10 13:37
+    And the email address change confirmation period is set to 4 days
+    And I follow "Change Email"
+    And I request to change my email to "valid2@archiveofourown.org"
+  Then I should see "If you don't confirm your request by April 14, 2020"
+    And 1 email should be delivered to "bar@ao3.org"
+    And 1 email should be delivered to "valid2@archiveofourown.org"
+    And the email should contain "request to change the email address"
+
+  When it is currently 2020-04-12 14:00
+    And I request to change my email to "another@archiveofourown.org"
+  Then I should see "You have requested to change your email address to another@archiveofourown.org."
+    And I should see "If you don't confirm your request by April 16, 2020"
+    # The original email gets another notification
+    And 2 emails should be delivered to "bar@ao3.org"
+    # Old link should be invalid
+    And 1 email should be delivered to "valid2@archiveofourown.org"
+  When I follow "confirm your email change" in the email
+  Then I should see "This email confirmation link is invalid or expired. Please check your email for the correct link or submit the email change form again."
+    And I should see "bar@ao3.org"
+    And I should see "You have requested to change your email address to another@archiveofourown.org"
+    But I should not see "valid2@archiveofourown.org"
+    # Newest email gets new link that should work
+    And 1 email should be delivered to "another@archiveofourown.org"
+    And the email should contain "request to change the email address"
+  When I follow "confirm your email change" in the email
+  Then I should see "Your email has been successfully updated."
+    And I should see "another@archiveofourown.org"
+    But I should not see "valid2@archiveofourown.org"
+    But I should not see "bar@ao3.org"
+
+Scenario: Changing email address -- after requesting password reset
 
   When I am logged out
     And I follow "Forgot password?"
@@ -129,35 +180,32 @@ Scenario: Changing email address after requesting password reset
   Then 1 email should be delivered to "bar@ao3.org"
   When all emails have been delivered
     And I am logged in as "editname"
-    And I want to edit my profile
-    And I change my email
-  Then I should see "Your email has been successfully updated"
+    And I follow "My Preferences"
+    And I follow "Change Email"
+    And I request to change my email to "valid2@archiveofourown.org"
+  Then I should see "You have requested to change your email address to valid2@archiveofourown.org."
     And 1 email should be delivered to "bar@ao3.org"
-    And the email should contain "the email associated with your account has been changed to"
-    And the email should contain "valid2@archiveofourown.org"
-    And the email should not contain "translation missing"
-  When I change my preferences to display my email address
-  Then I should see "My email address: valid2@archiveofourown.org"
+    And 1 email should be delivered to "valid2@archiveofourown.org"
+  When I follow "confirm your email change" in the email
+  Then I should see "Your email has been successfully updated."
+    And I should see "valid2@archiveofourown.org"
+    But I should not see "bar@ao3.org"
 
-Scenario: Changing email address -- can't be the same as another user's
-
-  When I enter a duplicate email
-  Then I should see "Email has already been taken"
-    And 0 emails should be delivered
-    And I should not see "Email addresses don't match!"
-    And I should not see "foo@ao3.org"
-    And I should see "bar@ao3.org"
-
-Scenario: Changing email address -- Translated email is sent when user enables locale settings
+Scenario: Changing email address -- translated emails are sent when user enables locale settings
     Given a locale with translated emails
       And the user "editname" enables translated emails
       And all emails have been delivered
     When I am logged in as "editname"
-      And I want to edit my profile
-      And I change my email
+      And I follow "My Preferences"
+      And I follow "Change Email"
+      And I request to change my email to "valid2@archiveofourown.org"
     Then the email address "bar@ao3.org" should be emailed
-      And the email should have "Email changed" in the subject
+      # TODO Bilka
+      #And the email should have "Email change request" in the subject
       And the email to email address "bar@ao3.org" should be translated
+      And 1 email should be delivered to "valid2@archiveofourown.org"
+      And the email should have "Confirm your email change" in the subject
+      And the email to email address "valid2@archiveofourown.org" should be translated
 
 Scenario: Date of birth - under age
 

--- a/features/step_definitions/email_custom_steps.rb
+++ b/features/step_definitions/email_custom_steps.rb
@@ -5,7 +5,7 @@ end
 Given "a locale with translated emails" do
   FactoryBot.create(:locale, iso: "new")
   # The footer keys are used in most emails
-  I18n.backend.store_translations(:new, { mailer: { general: { footer: { general: { about: { html: "Translated footer", text: "Translated footer" } } } } } })
+  I18n.backend.store_translations(:new, { mailer: { general: { footer: { about: { html: "Translated footer", text: "Translated footer" } } } } })
   I18n.backend.store_translations(:new, { kudo_mailer: { batch_kudo_notification: { subject: "Translated subject" } } })
   I18n.backend.store_translations(:new, { users: { mailer: { reset_password_instructions: { subject: "Translated subject" } } } })
 end

--- a/features/step_definitions/profile_steps.rb
+++ b/features/step_definitions/profile_steps.rb
@@ -28,22 +28,25 @@ When /^I remove details from my profile$/ do
   click_button("Update")
 end
 
-
-When /^I enter an incorrect password$/ do
-  click_link("Change Email")
-  fill_in("new_email", with: "valid2@archiveofourown.org")
-  fill_in("email_confirmation", with: "valid2@archiveofourown.org")
-  fill_in("password_check", with: "passw")
-  click_button("Change Email")
+When "the email address change confirmation period is set to {int} days" do |amount|
+  allow(Devise).to receive(:confirm_within).and_return(amount.days)
 end
 
+When "I start to change my email to {string}" do |email|
+  step %{I fill in "New email" with "#{email}"}
+  step %{I fill in "Enter new email again" with "#{email}"}
+  step %{I fill in "Password" with "password"}
+  step %{I press "Confirm New Email"}
+end
 
-When /^I change my email$/ do
-  click_link("Change Email")
-  fill_in("new_email", with: "valid2@archiveofourown.org")
-  fill_in("email_confirmation", with: "valid2@archiveofourown.org")
-  fill_in("password_check", with: "password")
-  click_button("Change Email")
+When "I confirm my email change request to {string}" do |email|
+  step %{I should see "Are you sure you want to change your email address to #{email}?"}
+  step %{I press "Yes, Change Email"}
+end
+
+When "I request to change my email to {string}" do |email|
+  step %{I start to change my email to "#{email}"}
+  step %{I confirm my email change request to "#{email}"}
 end
 
 
@@ -51,35 +54,6 @@ When /^I view my profile$/ do
   step %{I follow "My Dashboard"}
   step %{I should see "Dashboard"}
   click_link("Profile")
-end
-
-
-When /^I enter an invalid email$/ do
-  click_link("Change Email")
-  fill_in("new_email", with: "bob.bob.bob")
-  fill_in("email_confirmation", with: "bob.bob.bob")
-  fill_in("password_check", with: "password")
-  click_button("Change Email")
-end
-
-
-When "I enter non-matching emails" do
-  click_link("Change Email")
-  fill_in("new_email", with: "correct@example.com")
-  fill_in("email_confirmation", with: "invalid@example.com")
-  fill_in("password_check", with: "password")
-  click_button("Change Email")
-end
-
-When /^I enter a duplicate email$/ do
-  user = FactoryBot.create(:user, login: "testuser2", password: "password", email: "foo@ao3.org")
-  step %{confirmation emails have been delivered}
-
-  click_link("Change Email")
-  fill_in("new_email", with: "foo@ao3.org")
-  fill_in("email_confirmation", with: "foo@ao3.org")
-  fill_in("password_check", with: "password")
-  click_button("Change Email")
 end
 
 When /^I enter a birthdate that shows I am under age$/ do

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -318,7 +318,7 @@ end
 
 When /^I change my username to "([^"]*)"/ do |new_name|
   step %{I follow "My Preferences"}
-  step %{I follow "Change My Username"}
+  step %{I follow "Change Username"}
   fill_in("New username", with: new_name)
   fill_in("Password", with: "password")
   click_button("Change Username")

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -258,6 +258,8 @@ module NavigationHelpers
       edit_user_password_path
     when /^the (.*) mass bin$/i
       tag_wranglings_path(show: Regexp.last_match(1).pluralize)
+    when /^the orphan all works page$/i
+      new_orphan_path
 
     # Admin Pages
     when /^the admin-posts page$/i

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -209,11 +209,11 @@ describe UsersController do
       expect(flash[:error]).to include("Your password was incorrect. Please try again or log out and reset your password via the link on")
     end
 
-    xit "requires a valid email address" do # TODO Bilka
+    it "requires a valid email address" do
       put :confirm_change_email, params: { id: user, new_email: "wrong", email_confirmation: "wrong", password_check: "password" }
 
       expect(response).to render_template(:change_email)
-      expect(flash[:error]).to eq("Email should look like an email address")
+      expect(assigns[:user].errors.full_messages).to include("Email should look like an email address.")
     end
 
     it "disallows non-matching email confirmation" do
@@ -230,12 +230,12 @@ describe UsersController do
       expect(flash[:error]).to be_blank
     end
 
-    xit "disallows using another user's email" do # TODO Bilka
+    it "disallows using another user's email" do
       create(:user, email: "new@example.com")
-      put :confirm_change_email, params: { id: user, new_email: "new@example.com", email_confirmation: "NEW@example.com", password_check: "password" }
+      put :confirm_change_email, params: { id: user, new_email: "new@example.com", email_confirmation: "new@example.com", password_check: "password" }
 
       expect(response).to render_template(:change_email)
-      expect(flash[:error]).to eq("Email has already been taken")
+      expect(assigns[:user].errors.full_messages).to include("Email has already been taken")
     end
   end
 
@@ -246,21 +246,21 @@ describe UsersController do
       before { fake_login_known_user(user) }
 
       it "disallows invalid tokens" do
-        get :reconfirm_email, params: { id: user, confirmation_token: "foo"}
+        get :reconfirm_email, params: { id: user, confirmation_token: "foo" }
 
         it_redirects_to_with_error(change_email_user_path(user), "This email confirmation link is invalid or expired. Please check your email for the correct link or submit the email change form again.")
       end
     end
 
     context "when logged in as the wrong user" do
-      let (:another_user) { create(:user) }
+      let(:another_user) { create(:user) }
 
       before { fake_login_known_user(another_user) }
 
-      xit "the error tells the user to log out" do # TODO Bilka
-        get :reconfirm_email, params: { id: user, confirmation_token: "foo"}
+      it "the error tells the user to log out" do
+        get :reconfirm_email, params: { id: user, confirmation_token: "foo" }
 
-        it_redirects_to_with_error(user_path(another_user), "You are not logged in to the account whose email you are trying to change. Please log out and try again.")
+        it_redirects_to_with_error(user_path(user), "You are not logged in to the account whose email you are trying to change. Please log out and try again.")
       end
     end
   end

--- a/spec/mailers/archive_devise_mailer_spec.rb
+++ b/spec/mailers/archive_devise_mailer_spec.rb
@@ -70,7 +70,7 @@ describe ArchiveDeviseMailer do
   end
 
   describe "#confirmation_instructions" do
-    let(:user) { create(:user, confirmation_sent_at: Time.new(2020, 4, 10, 10, 51)) }
+    let(:user) { create(:user, confirmation_sent_at: Time.new(2020, 4, 10, 10, 51, 0, "+00:00")) }
     subject(:email) { ArchiveDeviseMailer.confirmation_instructions(user, token: "fakeToken") }
 
     # Test the headers

--- a/spec/mailers/archive_devise_mailer_spec.rb
+++ b/spec/mailers/archive_devise_mailer_spec.rb
@@ -23,14 +23,14 @@ describe ArchiveDeviseMailer do
 
       describe "HTML version" do
         it "has the correct content" do
-          expect(email).to have_html_part_content("Dear <")
+          expect(email).to have_html_part_content("Hi <")
           expect(email).to have_html_part_content("Change my password.")
         end
       end
 
       describe "text version" do
         it "has the correct content" do
-          expect(email).to have_text_part_content("Dear #{user.login},")
+          expect(email).to have_text_part_content("Hi #{user.login},")
           expect(email).not_to have_text_part_content("Change my password.")
         end
       end
@@ -55,17 +55,53 @@ describe ArchiveDeviseMailer do
 
       describe "HTML version" do
         it "has the correct content" do
-          expect(email).to have_html_part_content("Dear <")
+          expect(email).to have_html_part_content("Hi <")
           expect(email).to have_html_part_content("Change my password.")
         end
       end
 
       describe "text version" do
         it "has the correct content" do
-          expect(email).to have_text_part_content("Dear #{user.login},")
+          expect(email).to have_text_part_content("Hi #{user.login},")
           expect(email).not_to have_text_part_content("Change my password.")
         end
       end
     end
+  end
+
+  describe "#confirmation_instructions" do
+    let(:user) { create(:user, confirmation_sent_at: Time.new(2020, 4, 10, 10, 51)) }
+    subject(:email) { ArchiveDeviseMailer.confirmation_instructions(user, token: "fakeToken") }
+
+    # Test the headers
+    it_behaves_like "an email with a valid sender"
+
+    it "has the correct subject line" do
+      subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Confirm your email change"
+      expect(email.subject).to eq(subject)
+    end
+
+    # Test both body contents
+    it_behaves_like "a multipart email"
+
+    it_behaves_like "a translated email"
+
+    describe "HTML version" do
+      it "has the correct content" do
+        expect(email).to have_html_part_content("Hi,")
+        expect(email).to have_html_part_content(">confirm your email change</a> within #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES} days")
+        expect(email).to have_html_part_content("If you don't confirm your request by April #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES + 10}, 2020, the link in")
+      end
+    end
+
+    describe "text version" do
+      it "has the correct content" do
+        expect(email).to have_text_part_content("Hi,")
+        expect(email).to have_text_part_content("please confirm your email change within #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES} days")
+        expect(email).to have_text_part_content("If you don't confirm your request by April #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES + 10}, 2020, the link in")
+      end
+    end
+
+    # TODO Bilka PAC footer
   end
 end

--- a/spec/mailers/archive_devise_mailer_spec.rb
+++ b/spec/mailers/archive_devise_mailer_spec.rb
@@ -101,7 +101,5 @@ describe ArchiveDeviseMailer do
         expect(email).to have_text_part_content("If you don't confirm your request by April #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES + 10}, 2020, the link in")
       end
     end
-
-    # TODO Bilka PAC footer
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -10,7 +10,7 @@ describe UserMailer do
     # Test the headers
     it_behaves_like "an email with a valid sender"
 
-    xit "has the correct subject line" do # TODO Bilka
+    it "has the correct subject line" do
       subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Email change request"
       expect(email.subject).to eq(subject)
     end
@@ -22,9 +22,10 @@ describe UserMailer do
 
     describe "HTML version" do
       it "has the correct content" do
-        # TODO Bilka
-        #expect(email).to have_text_part_content("Hi #{login},")
-        #expect(email).to have_text_part_content("If you made this request, check your email at #{new_email} within #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES} days to confirm your email change")
+        expect(email).to have_html_part_content("Hi <b")
+        expect(email).to have_html_part_content(">#{login}</b>,")
+        expect(email).to have_html_part_content("If you made this request, check your email at <a")
+        expect(email).to have_html_part_content("#{new_email}</a> within #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES} days to confirm your email change")
 
         expect(email).to have_html_part_content("don't understand why you received this email, please <a")
         expect(email).to have_html_part_content(">contact Policy & Abuse</a>.")
@@ -33,9 +34,8 @@ describe UserMailer do
 
     describe "text version" do
       it "has the correct content" do
-        # TODO Bilka
-        #expect(email).to have_text_part_content("Hi #{login},")
-        #expect(email).to have_text_part_content("If you made this request, check your email at #{new_email} within #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES} days to confirm your email change")
+        expect(email).to have_text_part_content("Hi #{login},")
+        expect(email).to have_text_part_content("If you made this request, check your email at #{new_email} within #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES} days to confirm your email change")
 
         expect(email).to have_text_part_content("If you don't understand why you received this email, please contact Policy & Abuse")
       end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-
+# TODO Bilka change_email spec
 describe UserMailer do
   describe "creatorship_request" do
     subject(:email) { UserMailer.creatorship_request(work_creatorship.id, author.id) }

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -623,7 +623,7 @@ describe UserMailer do
 
     describe "HTML version" do
       it "has the correct content" do
-        expect(email).to have_html_part_content("Dear <b")
+        expect(email).to have_html_part_content("Hi <b")
         expect(email).to have_html_part_content("#{user.login}</b>,")
         expect(email).to have_html_part_content("> has been hidden")
       end
@@ -631,7 +631,7 @@ describe UserMailer do
 
     describe "text version" do
       it "has the correct content" do
-        expect(email).to have_text_part_content("Dear #{user.login},")
+        expect(email).to have_text_part_content("Hi #{user.login},")
         expect(email).to have_text_part_content(") has been hidden")
       end
     end
@@ -776,7 +776,7 @@ describe UserMailer do
 
     describe "HTML version" do
       it "has the correct content" do
-        expect(email).to have_html_part_content("Dear <b")
+        expect(email).to have_html_part_content("Hi <b")
         expect(email).to have_html_part_content("#{user.login}</b>,")
         expect(email).to have_html_part_content("> has been flagged by our automated system")
       end
@@ -784,7 +784,7 @@ describe UserMailer do
 
     describe "text version" do
       it "has the correct content" do
-        expect(email).to have_text_part_content("Dear #{user.login},")
+        expect(email).to have_text_part_content("Hi #{user.login},")
         expect(email).to have_text_part_content(") has been flagged by our automated system")
       end
     end
@@ -812,14 +812,14 @@ describe UserMailer do
 
     describe "HTML version" do
       it "has the correct content" do
-        expect(email).to have_html_part_content("Dear <b")
+        expect(email).to have_html_part_content("Hi <b")
         expect(email).to have_html_part_content("#{user.login}</b>,")
       end
     end
 
     describe "text version" do
       it "has the correct content" do
-        expect(email).to have_text_part_content("Dear #{user.login},")
+        expect(email).to have_text_part_content("Hi #{user.login},")
       end
     end
   end
@@ -848,7 +848,7 @@ describe UserMailer do
 
     describe "HTML version" do
       it "has the correct content" do
-        expect(email).to have_html_part_content("Dear <b")
+        expect(email).to have_html_part_content("Hi <b")
         expect(email).to have_html_part_content("#{user.login}</b>,")
         expect(email).to have_html_part_content(collection.title)
         expect(email).to have_html_part_content(work.title)
@@ -857,7 +857,7 @@ describe UserMailer do
 
     describe "text version" do
       it "has the correct content" do
-        expect(email).to have_text_part_content("Dear #{user.login},")
+        expect(email).to have_text_part_content("Hi #{user.login},")
         expect(email).to have_text_part_content(collection.title)
         expect(email).to have_text_part_content(work.title)
       end
@@ -1125,7 +1125,7 @@ describe UserMailer do
 
     context "HTML version" do
       it "has the correct content" do
-        expect(email).to have_html_part_content("Dear <b")
+        expect(email).to have_html_part_content("Hi <b")
         expect(email).to have_html_part_content("#{user.login}</b>,")
         expect(email).to have_html_part_content("was deleted at your request")
       end
@@ -1133,7 +1133,7 @@ describe UserMailer do
 
     context "text version" do
       it "has the correct content" do
-        expect(email).to have_text_part_content("Dear #{user.login},")
+        expect(email).to have_text_part_content("Hi #{user.login},")
         expect(email).to have_text_part_content("Your work \"#{work.title}\" was deleted at your request")
       end
     end
@@ -1178,7 +1178,7 @@ describe UserMailer do
 
     context "HTML version" do
       it "has the correct content" do
-        expect(email).to have_html_part_content("Dear <b")
+        expect(email).to have_html_part_content("Hi <b")
         expect(email).to have_html_part_content("#{user.login}</b>,")
         expect(email).to have_html_part_content("was deleted from the Archive by a site admin")
       end
@@ -1186,7 +1186,7 @@ describe UserMailer do
 
     context "text version" do
       it "has the correct content" do
-        expect(email).to have_text_part_content("Dear #{user.login},")
+        expect(email).to have_text_part_content("Hi #{user.login},")
         expect(email).to have_text_part_content("Your work \"#{work.title}\" was deleted from the Archive by a site admin")
       end
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,6 +1,47 @@
 require "spec_helper"
-# TODO Bilka change_email spec
+
 describe UserMailer do
+  describe "#change_email" do
+    let(:login) { "changer" }
+    let(:new_email) { "new@example.com" }
+    let(:user) { create(:user, login: login) }
+    subject(:email) { UserMailer.change_email(user.id, "old@example.com", new_email) }
+
+    # Test the headers
+    it_behaves_like "an email with a valid sender"
+
+    xit "has the correct subject line" do # TODO Bilka
+      subject = "[#{ArchiveConfig.APP_SHORT_NAME}] Email change request"
+      expect(email.subject).to eq(subject)
+    end
+
+    # Test both body contents
+    it_behaves_like "a multipart email"
+
+    it_behaves_like "a translated email"
+
+    describe "HTML version" do
+      it "has the correct content" do
+        # TODO Bilka
+        #expect(email).to have_text_part_content("Hi #{login},")
+        #expect(email).to have_text_part_content("If you made this request, check your email at #{new_email} within #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES} days to confirm your email change")
+
+        expect(email).to have_html_part_content("don't understand why you received this email, please <a")
+        expect(email).to have_html_part_content(">contact Policy & Abuse</a>.")
+      end
+    end
+
+    describe "text version" do
+      it "has the correct content" do
+        # TODO Bilka
+        #expect(email).to have_text_part_content("Hi #{login},")
+        #expect(email).to have_text_part_content("If you made this request, check your email at #{new_email} within #{ArchiveConfig.DAYS_UNTIL_RESET_PASSWORD_LINK_EXPIRES} days to confirm your email change")
+
+        expect(email).to have_text_part_content("If you don't understand why you received this email, please contact Policy & Abuse")
+      end
+    end
+  end
+
   describe "creatorship_request" do
     subject(:email) { UserMailer.creatorship_request(work_creatorship.id, author.id) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -272,6 +272,7 @@ describe User do
         end
 
         it "allows changing email" do
+          existing_user.skip_reconfirmation!
           existing_user.update!(email: "new_email@example.com")
           expect(existing_user.email).to eq("new_email@example.com")
         end
@@ -324,6 +325,7 @@ describe User do
 
     context "when email is changed" do
       before do
+        existing_user.skip_reconfirmation!
         existing_user.update!(email: "newemail@example.com")
         existing_user.reload
       end
@@ -345,6 +347,7 @@ describe User do
 
       before do
         User.current_user = admin
+        existing_user.skip_reconfirmation!
         existing_user.update!(email: "new_email@example.com")
         existing_user.reload
       end

--- a/test/mailers/previews/archive_devise_mailer_preview.rb
+++ b/test/mailers/previews/archive_devise_mailer_preview.rb
@@ -6,4 +6,10 @@ class ArchiveDeviseMailerPreview < ApplicationMailerPreview
     user = create(:user, :for_mailer_preview)
     ArchiveDeviseMailer.reset_password_instructions(user, "fakeToken")
   end
+
+  # URL: /rails/mailers/archive_devise_mailer/confirmation_instructions?confirmation_sent_at=2025-01-23T20:00
+  def confirmation_instructions
+    user = create(:user, :for_mailer_preview, confirmation_sent_at: (params[:confirmation_sent_at] ? params[:confirmation_sent_at].to_time : Time.current))
+    ArchiveDeviseMailer.confirmation_instructions(user, "fakeToken")
+  end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -109,7 +109,7 @@ class UserMailerPreview < ApplicationMailerPreview
   def change_email
     user = create(:user, :for_mailer_preview)
     old_email = user.email
-    new_email = "new_email"
+    new_email = "new_email@example.com"
     UserMailer.change_email(user.id, old_email, new_email)
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [ ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [ ] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [ ] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-XXXX (Please fill in issue number and remove this comment.)

## Purpose

What does this PR do?

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead.

You can remove this section if there are already full testing instructions in the Jira issue.

## References

Are there other relevant issues/pull requests/mailing list discussions? If not, you can remove this section.

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
